### PR TITLE
Enhance swagger: add [401,404,500] responses

### DIFF
--- a/swagger/data_objects_service.swagger.json
+++ b/swagger/data_objects_service.swagger.json
@@ -18,7 +18,7 @@
     "/ga4gh/dos/v1/databundles": {
       "post": {
         "summary": "Create a new Data Bundle",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "CreateDataBundle",
         "responses": {
           "200": {
@@ -26,6 +26,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghCreateDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -46,7 +55,7 @@
     "/ga4gh/dos/v1/databundles/list": {
       "post": {
         "summary": "List the Data Bundles",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "ListDataBundles",
         "responses": {
           "200": {
@@ -54,6 +63,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghListDataBundlesResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -74,7 +92,7 @@
     "/ga4gh/dos/v1/databundles/{data_bundle_id}": {
       "get": {
         "summary": "Retrieve a Data Bundle",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "GetDataBundle",
         "responses": {
           "200": {
@@ -82,6 +100,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -105,7 +132,7 @@
       },
       "delete": {
         "summary": "Delete a Data Bundle",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "DeleteDataBundle",
         "responses": {
           "200": {
@@ -113,6 +140,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghDeleteDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -129,7 +165,7 @@
       },
       "put": {
         "summary": "Update a Data Bundle",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "UpdateDataBundle",
         "responses": {
           "200": {
@@ -137,6 +173,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghUpdateDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -162,7 +207,7 @@
     },
     "/ga4gh/dos/v1/databundles/{data_bundle_id}/versions": {
       "get": {
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "GetDataBundleVersions",
         "responses": {
           "200": {
@@ -170,6 +215,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataBundleVersionsResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -188,7 +242,7 @@
     "/ga4gh/dos/v1/dataobjects": {
       "post": {
         "summary": "Make a new Data Object",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "CreateDataObject",
         "responses": {
           "200": {
@@ -196,6 +250,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghCreateDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -216,7 +279,7 @@
     "/ga4gh/dos/v1/dataobjects/list": {
       "post": {
         "summary": "List the Data Objects",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "ListDataObjects",
         "responses": {
           "200": {
@@ -224,6 +287,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghListDataObjectsResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -244,7 +316,7 @@
     "/ga4gh/dos/v1/dataobjects/{data_object_id}": {
       "get": {
         "summary": "Retrieve a Data Object",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "GetDataObject",
         "responses": {
           "200": {
@@ -252,6 +324,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -275,7 +356,7 @@
       },
       "delete": {
         "summary": "Delete a Data Object index entry",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "DeleteDataObject",
         "responses": {
           "200": {
@@ -283,6 +364,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghDeleteDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -299,7 +389,7 @@
       },
       "put": {
         "summary": "Update a Data Object",
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "UpdateDataObject",
         "responses": {
           "200": {
@@ -307,6 +397,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghUpdateDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -332,7 +431,7 @@
     },
     "/ga4gh/dos/v1/dataobjects/{data_object_id}/versions": {
       "get": {
-        "x-swagger-router-controller": "ga4gh.dos.server", 
+        "x-swagger-router-controller": "ga4gh.dos.server",
         "operationId": "GetDataObjectVersions",
         "responses": {
           "200": {
@@ -340,6 +439,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataObjectVersionsResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [


### PR DESCRIPTION
This PR enhances the swagger schema by adding  401,404,500 response values to the expected responses.