### PR TITLE
Change title to description, Client headers

### DIFF
--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -536,7 +536,7 @@ definitions:
     properties:
       id:
         type: string
-        title: |-
+        description: |-
           REQUIRED
           An identifier, unique to this Data Bundle
       data_object_ids:
@@ -657,13 +657,12 @@ definitions:
         type: array
         items:
           type: string
-        title: |-
+        description: |-
           OPTIONAL
           A list of strings that can be used to find this Data Object.
           These aliases can be used to represent the Data Object's location in
           a directory (e.g. "bucket/folder/file.name") to make Data Objects
           more discoverable. They might also be used to represent
-    title: 'Data Object: a file, API or other resource'
   DeleteDataBundleResponse:
     type: object
     properties:
@@ -778,7 +777,7 @@ definitions:
           this string.
       checksum:
         $ref: '#/definitions/ChecksumRequest'
-        title: |-
+        description: |-
           OPTIONAL
           If provided will only return data object messages with the provided
           checksum. If the checksum type is provided
@@ -833,7 +832,7 @@ definitions:
     properties:
       data_bundle_id:
         type: string
-        title: REQUIRED
+        description: REQUIRED
       data_bundle:
         $ref: '#/definitions/DataBundle'
         description: |-

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -591,7 +591,6 @@ definitions:
         $ref: '#/definitions/SystemMetadata'
       user_metadata:
         $ref: '#/definitions/UserMetadata'
-    title: 'Data Bundle: A collection of Data Objects'
   DataObject:
     type: object
     properties:
@@ -797,8 +796,6 @@ definitions:
           The continuation token, which is used to page through large result sets.
           To get the next page of results, set this parameter to the value of
           `next_page_token` from the previous response.
-    title: |-
-      List and filter Data Objects
     description: |-
       Allows a requester to list and filter Data Objects. Only Data Objects
       matching all of the requested parameters will be returned.

--- a/python/ga4gh/dos/client.py
+++ b/python/ga4gh/dos/client.py
@@ -32,10 +32,12 @@ int64_format = SwaggerFormat(
 class Client:
     """
     simple wrapper around bravado swagger Client. see
-    https://github.com/Yelp/bravado/blob/master/docs/source/configuration.rst#client-configuration
+    https://github.com/Yelp/bravado/blob/master/docs/source/configuration.rst#client-configuration # NOQA
     https://github.com/Yelp/bravado#example-with-basic-authentication
     """
-    def __init__(self, url, config=DEFAULT_CONFIG, http_client=None, request_headers=None):
+    def __init__(
+          self, url,
+          config=DEFAULT_CONFIG, http_client=None, request_headers=None):
         swagger_path = '{}/swagger.json'.format(url.rstrip("/"))
         config['formats'] = [int64_format]
         self._config = config

--- a/python/ga4gh/dos/client.py
+++ b/python/ga4gh/dos/client.py
@@ -35,13 +35,14 @@ class Client:
     https://github.com/Yelp/bravado/blob/master/docs/source/configuration.rst#client-configuration
     https://github.com/Yelp/bravado#example-with-basic-authentication
     """
-    def __init__(self, url, config=DEFAULT_CONFIG, http_client=None):
+    def __init__(self, url, config=DEFAULT_CONFIG, http_client=None, request_headers=None):
         swagger_path = '{}/swagger.json'.format(url.rstrip("/"))
         config['formats'] = [int64_format]
         self._config = config
         self.models = SwaggerClient.from_url(swagger_path,
                                              config=config,
-                                             http_client=http_client)
+                                             http_client=http_client,
+                                             request_headers=request_headers)
         self.client = self.models.DataObjectService
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "ga4gh.dos"
     ],
     namespace_packages=["ga4gh"],
-    url="https://github.com/ga4gh/data-object-schemas",
+    url="https://github.com/ga4gh/data-object-service-schemas",
     entry_points={
         'console_scripts': [
             'ga4gh_dos_server=ga4gh.dos.server:main',

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
-    version='0.2.0',
+    version='0.2.1',
     keywords=['genomics'],
     # Use setuptools_scm to set the version number automatically from Git
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
It seems like a change to bravado interprets the `title` field of OpenAPI differently. This PR changes the title to description as well as adding an option for setting request headers for the client.