### PR TITLE
Use 'required' tag instead of comments in schema

### DIFF
--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -73,21 +73,21 @@ paths:
         - name: alias
           in: query
           type: string
+          required: false
           description: |-
-            OPTIONAL
             If provided returns Data Bundles that have any alias that matches the
             request.
         - name: checksum
           in: query
           type: string
+          required: true
           description: |-
-            REQUIRED
             The hexlified checksum that one would like to match on.
         - name: checksum_type
           in: query
           type: string
+          required: false
           description: |-
-            OPTIONAL
             If provided will restrict responses to those that match the provided
             type.
 
@@ -100,15 +100,15 @@ paths:
           in: query
           type: integer
           format: int32
+          required: false
           description: |-
-            OPTIONAL
             Specifies the maximum number of results to return in a single page.
             If unspecified, a system default will be used.
         - name: page_token
           type: string
           in: query
+          required: false
           description: |-
-            OPTIONAL
             The continuation token, which is used to page through large result sets.
             To get the next page of results, set this parameter to the value of
             `next_page_token` from the previous response.
@@ -150,12 +150,11 @@ paths:
           required: true
           type: string
         - name: version
+          required: false
           description: |-
-            OPTIONAL
             If provided will return the requested version of the selected Data Bundle.
             Otherwise, only the latest version is returned.
           in: query
-          required: false
           type: string
       tags:
         - DataObjectService
@@ -316,27 +315,27 @@ paths:
         - name: alias
           in: query
           type: string
+          required: false
           description: |-
-            OPTIONAL
             If provided will only return Data Objects with the given alias.
         - name: url
           in: query
           type: string
+          required: false
           description: |-
-            OPTIONAL
             If provided will return only Data Objects with a that URL matches
             this string.
         - name: checksum
           in: query
           type: string
+          required: true
           description: |-
-            REQUIRED
             The hexlified checksum that one would like to match on.
         - name: checksum_type
           in: query
           type: string
+          required: false
           description: |-
-            OPTIONAL
             If provided will restrict responses to those that match the provided
             type.
 
@@ -349,15 +348,15 @@ paths:
           in: query
           type: integer
           format: int32
+          required: false
           description: |-
-            OPTIONAL
             Specifies the maximum number of results to return in a single page.
             If unspecified, a system default will be used.
         - name: page_token
           in: query
           type: string
+          required: false
           description: |-
-            OPTIONAL
             The continuation token, which is used to page through large result sets.
             To get the next page of results, set this parameter to the value of
             `next_page_token` from the previous response.
@@ -399,11 +398,10 @@ paths:
           required: true
           type: string
         - name: version
+          required: false
           description: |-
-            OPTIONAL
             If provided will return the requested version of the selected Data Object.
           in: query
-          required: false
           type: string
       tags:
         - DataObjectService

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -80,7 +80,7 @@ paths:
         - name: checksum
           in: query
           type: string
-          required: true
+          required: false
           description: |-
             The hexlified checksum that one would like to match on.
         - name: checksum_type

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -536,16 +536,15 @@ definitions:
             A set of key-value pairs that represent metadata provided by the uploader.
   Checksum:
     type: object
+    required: ['checksum']
     properties:
       checksum:
         type: string
         description: |-
-          REQUIRED
           The hex-string encoded checksum for the Data.
       type:
         type: string
         description: |-
-          OPTIONAL
           The digest method used to create the checksum. If left unspecified md5
           will be assumed.
 
@@ -561,19 +560,19 @@ definitions:
         $ref: '#/definitions/DataBundle'
   CreateDataBundleResponse:
     type: object
+    required: ['data_bundle_id']
     properties:
       data_bundle_id:
         type: string
         description: |-
-          REQUIRED
           The identifier of the Data Bundle created.
   CreateDataObjectRequest:
     type: object
+    required: ['data_object']
     properties:
       data_object:
         $ref: '#/definitions/DataObject'
         description: |-
-          REQUIRED
           The data object to be created. The ID scheme is left up to the
           implementor but should be unique to the server instance.
     description: |-
@@ -589,36 +588,32 @@ definitions:
         description: The ID of the created Data Object.
   DataBundle:
     type: object
+    required: ['id', 'data_object_ids', 'created', 'updated', 'version', 'checksums']
     properties:
       id:
         type: string
         description: |-
-          REQUIRED
           An identifier, unique to this Data Bundle
       data_object_ids:
         type: array
         items:
           type: string
         description: |-
-          REQUIRED
           The list of Data Objects that this Data Bundle contains.
       created:
         type: string
         format: date-time
         description: |-
-          REQUIRED
           Timestamp of object creation in RFC3339.
       updated:
         type: string
         format: date-time
         description: |-
-          REQUIRED
           Timestamp of update in RFC3339, identical to create timestamp in systems
           that do not support updates.
       version:
         type: string
         description: |-
-          REQUIRED
           A string representing a version, some systems may use checksum, a RFC3339
           timestamp, or incrementing version number. For systems that do not support
           versioning please use your update timestamp as your version.
@@ -627,21 +622,18 @@ definitions:
         items:
           $ref: '#/definitions/Checksum'
         description: |-
-          REQUIRED
           At least one checksum must be provided.
           The data bundle checksum is computed over all the checksums of the
           Data Objects that bundle contains.
       description:
         type: string
         description: |-
-          OPTIONAL
           A human readable description.
       aliases:
         type: array
         items:
           type: string
         description: |-
-          OPTIONAL
           A list of strings that can be used to identify this Data Bundle.
       system_metadata:
         $ref: '#/definitions/SystemMetadata'
@@ -649,45 +641,39 @@ definitions:
         $ref: '#/definitions/UserMetadata'
   DataObject:
     type: object
+    required: ['id', 'size', 'created', 'checksums']
     properties:
       id:
         type: string
         description: |-
-          REQUIRED
           An identifier unique to this Data Object.
       name:
         type: string
         description: |-
-          OPTIONAL
           A string that can be optionally used to name a Data Object.
       size:
         type: string
         format: int64
         description: |-
-          REQUIRED
           The computed size in bytes.
       created:
         type: string
         format: date-time
         description: |-
-          REQUIRED
           Timestamp of object creation in RFC3339.
       updated:
         type: string
         format: date-time
         description: |-
-          OPTIONAL
           Timestamp of update in RFC3339, identical to create timestamp in systems
           that do not support updates.
       version:
         type: string
         description: |-
-          OPTIONAL
           A string representing a version.
       mime_type:
         type: string
         description: |-
-          OPTIONAL
           A string providing the mime-type of the Data Object.
           For example, "application/json".
       checksums:
@@ -695,26 +681,22 @@ definitions:
         items:
           $ref: '#/definitions/Checksum'
         description: |-
-          REQUIRED
           The checksum of the Data Object. At least one checksum must be provided.
       urls:
         type: array
         items:
           $ref: '#/definitions/URL'
         description: |-
-          OPTIONAL
           The list of URLs that can be used to access the Data Object.
       description:
         type: string
         description: |-
-          OPTIONAL
           A human readable description of the contents of the Data Object.
       aliases:
         type: array
         items:
           type: string
         description: |-
-          OPTIONAL
           A list of strings that can be used to find this Data Object.
           These aliases can be used to represent the Data Object's location in
           a directory (e.g. "bucket/folder/file.name") to make Data Objects
@@ -726,11 +708,11 @@ definitions:
         type: string
   DeleteDataObjectResponse:
     type: object
+    required: ['data_object_id']
     properties:
       data_object_id:
         type: string
         description: |-
-          REQUIRED
           The identifier of the Data Object deleted.
   GetDataBundleResponse:
     type: object
@@ -739,32 +721,32 @@ definitions:
         $ref: '#/definitions/DataBundle'
   GetDataBundleVersionsResponse:
     type: object
+    required: ['data_bundles']
     properties:
       data_bundles:
         type: array
         items:
           $ref: '#/definitions/DataBundle'
         description: |-
-          REQUIRED
           All versions of the Data Bundles that match the GetDataBundleVersions
           request.
   GetDataObjectResponse:
     type: object
+    required: ['data_object']
     properties:
       data_object:
         $ref: '#/definitions/DataObject'
         description: |-
-          REQUIRED
           The Data Object that coincides with a specific GetDataObjectRequest.
   GetDataObjectVersionsResponse:
     type: object
+    required: ['data_objects']
     properties:
       data_objects:
         type: array
         items:
           $ref: '#/definitions/DataObject'
         description: |-
-          REQUIRED
           All versions of the Data Objects that match the GetDataObjectVersions
           request.
   ListDataBundlesRequest:
@@ -773,22 +755,20 @@ definitions:
       page_size and page_token are provided for retrieving a large number of
       results.
     type: object
+    required: ['checksum']
     properties:
       alias:
         type: string
         description: |-
-          OPTIONAL
           If provided returns Data Bundles that have any alias that matches the
           request.
       checksum:
         type: string
         description: |-
-          REQUIRED
           The hexlified checksum that one would like to match on.
       checksum_type:
         type: string
         description: |-
-          OPTIONAL
           If provided will restrict responses to those that match the provided
           type.
 
@@ -801,13 +781,11 @@ definitions:
         type: integer
         format: int32
         description: |-
-          OPTIONAL
           Specifies the maximum number of results to return in a single page.
           If unspecified, a system default will be used.
       page_token:
         type: string
         description: |-
-          OPTIONAL
           The continuation token, which is used to page through large result sets.
           To get the next page of results, set this parameter to the value of
           `next_page_token` from the previous response.
@@ -830,27 +808,24 @@ definitions:
           results. This field will be empty if there aren't any additional results.
   ListDataObjectsRequest:
     type: object
+    required: ['checksum']
     properties:
       alias:
         type: string
         description: |-
-          OPTIONAL
           If provided will only return Data Objects with the given alias.
       url:
         type: string
         description: |-
-          OPTIONAL
           If provided will return only Data Objects with a that URL matches
           this string.
       checksum:
         type: string
         description: |-
-          REQUIRED
           The hexlified checksum that one would like to match on.
       checksum_type:
         type: string
         description: |-
-          OPTIONAL
           If provided will restrict responses to those that match the provided
           type.
 
@@ -863,13 +838,11 @@ definitions:
         type: integer
         format: int32
         description: |-
-          OPTIONAL
           Specifies the maximum number of results to return in a single page.
           If unspecified, a system default will be used.
       page_token:
         type: string
         description: |-
-          OPTIONAL
           The continuation token, which is used to page through large result sets.
           To get the next page of results, set this parameter to the value of
           `next_page_token` from the previous response.
@@ -895,11 +868,11 @@ definitions:
       token, that can be used to retrieve more results.
   URL:
     type: object
+    required: ['url']
     properties:
       url:
         type: string
         description: |-
-          REQUIRED
           A URL that can be used to access the file.
       system_metadata:
         $ref: '#/definitions/SystemMetadata'
@@ -907,43 +880,41 @@ definitions:
         $ref: '#/definitions/UserMetadata'
   UpdateDataBundleRequest:
     type: object
+    required: ['data_bundle_id', 'data_bundle']
     properties:
       data_bundle_id:
         type: string
-        description: REQUIRED
       data_bundle:
         $ref: '#/definitions/DataBundle'
         description: |-
-          REQUIRED
           The new Data Bundle content.
   UpdateDataBundleResponse:
     type: object
+    required: ['data_bundle_id']
     properties:
       data_bundle_id:
         type: string
         description: |-
-          REQUIRED
           The identifier of the Data Bundle updated.
   UpdateDataObjectRequest:
     type: object
+    required: ['data_object_id', 'data_object']
     properties:
       data_object_id:
         type: string
         description: |-
-          REQUIRED
           The identifier of the Data Object to be updated.
       data_object:
         $ref: '#/definitions/DataObject'
         description: |-
-          REQUIRED
           The new Data Object for this identifier.
   UpdateDataObjectResponse:
     type: object
+    required: ['data_object_id']
     properties:
       data_object_id:
         type: string
         description: |-
-          REQUIRED
           The identifier of the Data Object updated.
   ErrorResponse:
     description:

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -328,7 +328,7 @@ paths:
         - name: checksum
           in: query
           type: string
-          required: true
+          required: false
           description: |-
             The hexlified checksum that one would like to match on.
         - name: checksum_type


### PR DESCRIPTION
Closes #82. Closes #112.

Given #118 and #127 (i.e. all parameters to `/dataobjects` and `/databundles` are supposed to be optional) is it enough that the endpoints are already implicitly tested in the test suite? https://github.com/ga4gh/data-object-service-schemas/blob/8dc870a10320cf2c03d7cd7d9b4735688f87fd9f/python/test/test_server.py#L295