### PR TITLE
Fix Travis installing requirements twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
 - sudo apt-get update -qq
 - python setup.py sdist
 - pip install dist/ga4gh_dos_schemas-*.tar.gz
-- pip install -r requirements.txt
 script:
 - nosetests python/
 - flake8 --select=E121,E123,E126,E226,E24,E704,W503,W504 --ignore=E501 python/


### PR DESCRIPTION
Closes #130.
Travis will automatically install requirements specified in
requirements.txt in the install step, so specifying it in the
before_install step is redundant. It only shaves off half a second
but it seems cleaner to fix it.

https://docs.travis-ci.com/user/languages/python/#pip