### PR TITLE
Add basic service info (closes #115)

### DIFF
--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -11,12 +11,12 @@ consumes:
 produces:
   - application/json
 paths:
-  /service-info:
+  '/service-info':
     get:
       summary: Returns service version and other information
       operationId: GetServiceInfo
       responses:
-        200:
+        '200':
           description: Service information returned successfully
           schema:
             $ref: '#/definitions/ServiceInfoResponse'

--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -11,6 +11,18 @@ consumes:
 produces:
   - application/json
 paths:
+  /service-info:
+    get:
+      summary: Returns service version and other information
+      operationId: GetServiceInfo
+      responses:
+        200:
+          description: Service information returned successfully
+          schema:
+            $ref: '#/definitions/ServiceInfoResponse'
+      tags:
+        - DataObjectService
+      x-swagger-router-controller: ga4gh.dos.server
   /databundles:
     post:
       summary: Create a new Data Bundle
@@ -958,4 +970,17 @@ definitions:
       status_code:
         type: integer
         description: The integer representing the HTTP status code (e.g. 200, 404).
+  ServiceInfoResponse:
+    type: object
+    required: ['version']
+    properties:
+      version:
+        type: string
+        description: Service version
+      name:
+        type: string
+        description: Service name
+      description:
+        type: string
+        description: Service description
 

--- a/python/ga4gh/dos/controllers.py
+++ b/python/ga4gh/dos/controllers.py
@@ -12,6 +12,7 @@ import uuid
 import datetime
 from dateutil.parser import parse
 
+import ga4gh.dos
 
 DEFAULT_PAGE_SIZE = 100
 
@@ -421,3 +422,12 @@ def ListDataBundles(**kwargs):
     else:
         page = filtered
     return({"data_bundles": page}, 200)
+
+
+def GetServiceInfo(**kwargs):
+    info = {
+        'version': ga4gh.dos.__version__,
+        'description': "https://github.com/ga4gh/data-object-service-schemas",
+        'name': "Data Object Service"
+    }
+    return info, 200

--- a/python/test/test_server.py
+++ b/python/test/test_server.py
@@ -9,6 +9,7 @@ import time
 from bravado.requests_client import RequestsClient
 from bravado.exception import HTTPNotFound
 
+import ga4gh.dos
 from ga4gh.dos.client import Client
 
 SERVER_URL = 'http://localhost:8080/ga4gh/dos/v1'
@@ -622,3 +623,8 @@ class TestServer(unittest.TestCase):
                 data_bundle_id='NON-EXISTING-KEY').result()
         except HTTPNotFound as e:
             self.assertEqual(e.status_code, 404)
+
+    def test_service_info(self):
+        r = self._client.GetServiceInfo().result()
+        self.assertEqual(ga4gh.dos.__version__, r.version)
+


### PR DESCRIPTION
```
$ http get localhost:8080/ga4gh/dos/v1/service-info
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 131
Content-Type: application/json
Date: Fri, 13 Jul 2018 17:28:47 GMT
Server: Werkzeug/0.14.1 Python/2.7.14

{
    "description": "https://github.com/ga4gh/data-object-service-schemas",
    "name": "Data Object Service",
    "version": "0.3.1"
}
```