### PR TITLE
Remove redundant data_{obj,bdl}_id (closes #154)

### DIFF
--- a/openapi/data_object_service.swagger.yaml
+++ b/openapi/data_object_service.swagger.yaml
@@ -227,10 +227,11 @@ paths:
           in: path
           required: true
           type: string
+          description: The ID of the data bundle to update
         - name: body
           in: body
           required: true
-          description: The new content for the Data Bundle identified by the given data_bundle_id.
+          description: The new content for the Data Bundle identified by the given data_bundle_id. If the ID specified in the request body is different than that specified in the path, the data bundle's ID will be replaced with the one in the request body.
           schema:
             $ref: '#/definitions/UpdateDataBundleRequest'
       tags:
@@ -498,10 +499,11 @@ paths:
           in: path
           required: true
           type: string
+          description: The ID of the data object to update
         - name: body
           in: body
           required: true
-          description: The new Data Object for the given data_object_id.
+          description: The new Data Object for the given data_object_id. If the ID specified in the request body is different than that specified in the path, the data object's ID will be replaced with the one in the request body.
           schema:
             $ref: '#/definitions/UpdateDataObjectRequest'
       tags:
@@ -899,10 +901,8 @@ definitions:
         $ref: '#/definitions/UserMetadata'
   UpdateDataBundleRequest:
     type: object
-    required: ['data_bundle_id', 'data_bundle']
+    required: ['data_bundle']
     properties:
-      data_bundle_id:
-        type: string
       data_bundle:
         $ref: '#/definitions/DataBundle'
   UpdateDataBundleResponse:
@@ -915,12 +915,8 @@ definitions:
           The identifier of the Data Bundle updated.
   UpdateDataObjectRequest:
     type: object
-    required: ['data_object_id', 'data_object']
+    required: ['data_object']
     properties:
-      data_object_id:
-        type: string
-        description: |-
-          The identifier of the Data Object to be updated.
       data_object:
         $ref: '#/definitions/DataObject'
   UpdateDataObjectResponse:

--- a/python/test/test_server.py
+++ b/python/test/test_server.py
@@ -190,8 +190,7 @@ class TestServer(unittest.TestCase):
             size="12345",
             checksums=[Checksum(checksum="def", type="md5")],
             urls=[URL(url="a"), URL(url="b"), URL(url="c")])
-        update_request = UpdateDataObjectRequest(
-            data_object=update_data_object, data_object_id=data_object_id)
+        update_request = UpdateDataObjectRequest(data_object=update_data_object)
         update_response = self._client.UpdateDataObject(
             data_object_id=data_object_id, body=update_request).result()
         updated_object = self._client.GetDataObject(
@@ -286,9 +285,7 @@ class TestServer(unittest.TestCase):
             size='12345',
             checksums=[Checksum(checksum="def", type="md5")],
             urls=[URL(url="a"), URL(url="b"), URL(url="c")])
-        update_request = UpdateDataObjectRequest(
-            data_object=update_data_object,
-            data_object_id=data_object['id'])
+        update_request = UpdateDataObjectRequest(data_object=update_data_object)
         update_response = self._client.UpdateDataObject(
             data_object_id=data_object.id,
             body=update_request).result()
@@ -530,9 +527,7 @@ class TestServer(unittest.TestCase):
             data_object_ids=[x.id for x in list_response.data_objects],
             checksums=[Checksum(checksum="def", type="md5")],
             aliases=["ghi"])
-        update_request = UpdateDataBundleRequest(
-            data_bundle_id=data_bundle.id,
-            data_bundle=update_data_bundle)
+        update_request = UpdateDataBundleRequest(data_bundle=update_data_bundle)
         update_response = self._client.UpdateDataBundle(
             data_bundle_id=data_bundle_id,
             body=update_request).result()


### PR DESCRIPTION
Tests and schema are fixed to this effect. Schema updated to show that
UpdateDataObject and UpdateDataBundle can be used to change the id of
an object or bundle.