### PR TITLE
Load schema locally by default (closes #114)

### DIFF
--- a/python/ga4gh/dos/client.py
+++ b/python/ga4gh/dos/client.py
@@ -10,11 +10,18 @@ following the OpenAPI schema.
 It currently assumes that the service also hosts the swagger.json, in a style
 similar to the demonstration server, :mod:`ga4gh.dos.server`.
 """
+try:  # for python3 compat
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
 from bravado.client import SwaggerClient
 from bravado.swagger_model import Loader
 from bravado.requests_client import RequestsClient
 from bravado_core.exception import SwaggerValidationError
 from bravado_core.formatter import SwaggerFormat
+
+import ga4gh.dos.schema
 
 DEFAULT_CONFIG = {
     'validate_requests': True,
@@ -50,12 +57,10 @@ class Client:
     """
     This class is the instantiated to create a new connection to a DOS. It
     connects to the service to download the swagger.json and returns a client
-    in the DataObjectService namespace.
-
-    ::
+    in the DataObjectService namespace::
 
         from ga4gh.dos.client import Client
-        client = Client("http://localhost:8000/ga4gh/dos/v1")
+        client = Client(url='http://localhost:8000/ga4gh/dos/v1')
 
         models = client.models
         c = client.client
@@ -72,6 +77,13 @@ class Client:
         # Finally, send the request to the service and evaluate the response.
         c.ListDataObjects(body=my_request).result()
 
+    If you want to use the client against a DOS implementation that does
+    not present a ``swagger.json``, then you can use the local schema::
+
+        client = Client(url='http://example.com/dos-base-path/', local=True)
+
+    Note that since this uses the local schema, some operations that are
+    not implemented by the implementation under test may fail.
 
     The class accepts a configuration dictionary that maps directly to the
     bravado configuration.
@@ -80,14 +92,54 @@ class Client:
     `bravado documentation
     <https://github.com/Yelp/bravado/blob/master/docs/source/configuration.rst>`_.
     """
-    def __init__(self, url, config=DEFAULT_CONFIG, http_client=None, request_headers=None):
-        swagger_path = '{}/swagger.json'.format(url.rstrip("/"))
-        config['formats'] = [int64_format]
+    def __init__(self, url=None, config=DEFAULT_CONFIG, http_client=None, request_headers=None, local=False):
+        """
+        Instantiates :class:`~bravado.client.SwaggerClient`.
+
+        For further documentation, refer to the documentation
+        for :meth:`bravado.client.SwaggerClient.from_url` and
+        :meth:`bravado.client.SwaggerClient.from_spec`.
+
+        :param str url: the URL of a Swagger specification. If ``local``
+                        is True, this should be the base URL of a DOS
+                        implementation (see ``local``).
+        :param dict config: see :meth:`bravado.client.SwaggerClient`
+        :param http_client: see :meth:`bravado.client.SwaggerClient`
+        :param request_headers: see :meth:`beravado.client.SwaggerClient`
+        :param bool local: set this to True to load the local schema.
+                           If this is True, the ``url`` parameter should
+                           point to the host and base path of the
+                           implementation under test::
+
+                              Client(url='https://example.com/ga4gh/dos/v1/', local=True)
+
+                           If False, the ``url`` parameter should point to a
+                           Swagger specification (``swagger.json``).
+        """
         self._config = config
-        self.models = SwaggerClient.from_url(swagger_path,
-                                             config=config,
-                                             http_client=http_client,
-                                             request_headers=request_headers)
+        config['formats'] = [int64_format]
+        if local:
+            # :meth:`bravado.client.SwaggerClient.from_spec` takes a schema
+            # as a Python dictionary, which we can conveniently expose
+            # via :func:`ga4gh.dos.schema.present_schema`.
+            schema = ga4gh.dos.schema.present_schema()
+
+            # Set schema['host'] and schema['basePath'] to the provided
+            # values if specified, otherwise leave them as they are
+            url = urlparse.urlparse(url)
+            schema['host'] = url.netloc or schema['host']
+            schema['basePath'] = url.path or schema['basePath']
+
+            self.models = SwaggerClient.from_spec(spec_dict=schema,
+                                                  config=config,
+                                                  http_client=http_client)
+        else:
+            # If ``local=False``, ``url`` is expected to be a ``swagger.json``
+            swagger_path = '{}/swagger.json'.format(url.rstrip("/"))
+            self.models = SwaggerClient.from_url(swagger_path,
+                                                 config=config,
+                                                 http_client=http_client,
+                                                 request_headers=request_headers)
         self.client = self.models.DataObjectService
 
     @classmethod

--- a/python/test/test_server.py
+++ b/python/test/test_server.py
@@ -681,3 +681,32 @@ class TestServer(unittest.TestCase):
         r = self._client.GetServiceInfo().result()
         self.assertEqual(ga4gh.dos.__version__, r.version)
 
+
+class TestServerWithLocalClient(TestServer):
+    """
+    Runs all of the test cases in the :class:`TestServer` test suite but
+    using :class:`ga4gh.dos.client.Client` when loaded locally. (In fact,
+    this suite is exactly the same as :class:`TestServer` except with
+    :meth:`setUpClass` modified to load the client locally.) Running all
+    the same tests is a little overkill but they're fast enough that it
+    really doesn't make a difference at all.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Start a test server
+        p = subprocess.Popen(['ga4gh_dos_server'], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, shell=False)
+        time.sleep(2)
+        cls._server_process = p
+
+        local_client = Client(SERVER_URL, local=True)
+
+        # setup logging
+        root = logging.getLogger()
+        root.setLevel(logging.ERROR)
+        logging.captureWarnings(True)
+
+        cls._models = local_client.models
+        cls._client = local_client.client
+        cls._local_client = local_client


### PR DESCRIPTION
Refactor :class:`ga4gh.dos.client.Client` to allow loading the schema
locally for implementations that may not present their own ``swagger.json``.
This is done by introducing a ``local`` parameter:

    from ga4gh.dos.client import Client
    client = Client(url='...', local=True)

This feature is not enabled by default, so the previous functionality is
preserved::

    client = Client(url='...')

I'm submitting this from out of sprint because it would make closing DataBiosphere/dos-azul-lambda#42 easier.