### PR TITLE
Improve compliance tests 

### DIFF
--- a/python/ga4gh/dos/test/compliance.py
+++ b/python/ga4gh/dos/test/compliance.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import functools
+import hashlib
 import json
 import logging
 import random
@@ -213,6 +214,49 @@ class AbstractComplianceTest(unittest.TestCase):
         :rtype: str
         """
         return path + '?' + urllib.urlencode(kwargs)
+
+    @staticmethod
+    def generate_data_objects(amount):
+        """
+        Yields a specified number of data objects with random attributes.
+
+        :param int amount: the amount of data objects to generate
+        """
+        for _ in range(amount):
+            yield {
+                'id': str(uuid.uuid1()),
+                'name': str(uuid.uuid1()),
+                'size': str(random.randint(2**0, 2**32)),
+                'created': '2018-08-29T19:58:52.648Z',
+                'updated': '2018-08-29T19:58:52.648Z',
+                'version': str(uuid.uuid1()),
+                'mime_type': 'application/json',
+                'checksums': [{
+                    'checksum': hashlib.md5(str(uuid.uuid1()).encode('utf-8')).hexdigest(),
+                    'type': 'md5'
+                }],
+                'urls': [
+                    {'url': str(uuid.uuid1())},
+                    {'url': str(uuid.uuid1())}
+                ],
+                'description': str(uuid.uuid1()),
+                'aliases': [str(uuid.uuid1())],
+            }
+
+    @staticmethod
+    def generate_data_bundles(amount):
+        """
+        Yields a specified number of data bundles with random attributes.
+
+        :param int amount: the amount of data bundles to generate
+        """
+        for bdl in AbstractComplianceTest.generate_data_objects(amount):
+            del bdl['name']
+            del bdl['size']
+            del bdl['mime_type']
+            del bdl['urls']
+            bdl.update({'data_object_ids': [str(uuid.uuid1()), str(uuid.uuid1())]})
+            yield bdl
 
     def get_random_data_object(self):
         """

--- a/python/ga4gh/dos/test/compliance.py
+++ b/python/ga4gh/dos/test/compliance.py
@@ -355,7 +355,7 @@ class AbstractComplianceTest(unittest.TestCase):
 
         # Next, given that the adjusting page_size works, we can test that paging
         # works by making a ListDataObjects request with page_size=2, then making
-        # two requests with page_size=1, and commparing that the results are the same.
+        # two requests with page_size=1, and comparing that the results are the same.
         both = self.dos_request('GET', self.get_query_url('/dataobjects', page_size=2))
         self.assertEqual(len(both['data_objects']), 2)
         first = self.dos_request('GET', self.get_query_url('/dataobjects', page_size=1))

--- a/python/ga4gh/dos/test/compliance.py
+++ b/python/ga4gh/dos/test/compliance.py
@@ -437,8 +437,7 @@ class AbstractComplianceTest(unittest.TestCase):
         data_object, url = self.get_random_data_object()
 
         # Try and update with no changes.
-        self.dos_request('PUT', url, body={'data_object': data_object,
-                                           'data_object_id': data_object['id']})
+        self.dos_request('PUT', url, body={'data_object': data_object})
         # We specify the Content-Type since Chalice looks for it when
         # deserializing the request body server-side
 
@@ -448,8 +447,7 @@ class AbstractComplianceTest(unittest.TestCase):
 
         # Try and update, this time with a change.
         update_response = self.dos_request('PUT', url,
-                                           body={'data_object': data_object,
-                                                 'data_object_id': data_object['id']})
+                                           body={'data_object': data_object})
         self.assertEqual(data_object['id'], update_response['data_object_id'])
 
         time.sleep(2)
@@ -500,8 +498,7 @@ class AbstractComplianceTest(unittest.TestCase):
         data_object.update(attributes)
 
         # Now update the old data object with the new attributes we added
-        self.dos_request('PUT', url, body={'data_object': data_object,
-                                           'data_object_id': data_object['id']})
+        self.dos_request('PUT', url, body={'data_object': data_object})
         time.sleep(2)  # Give the server some time to catch up
 
         # Test and see if the update took place

--- a/python/test/test_compliance.py
+++ b/python/test/test_compliance.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-import hashlib
-import random
-import uuid
-
 import werkzeug.datastructures
 
 import ga4gh.dos.server
@@ -47,32 +43,3 @@ class TestCompliance(AbstractComplianceTest):
         r = cls.client.open(method=meth, path='/ga4gh/dos/v1' + path,
                             data=body, headers=headers)
         return r.data, r.status_code
-
-    @staticmethod
-    def generate_data_objects(amount):
-        for _ in range(amount):
-            yield {
-                'id': str(uuid.uuid1()),
-                'name': str(uuid.uuid1()),
-                'created': '2018-08-29T19:58:52.648Z',
-                'size': str(random.randint(2**0, 2**32)),
-                'aliases': [str(uuid.uuid1())],
-                'urls': [
-                    {'url': str(uuid.uuid1())},
-                    {'url': str(uuid.uuid1())}
-                ],
-                'checksums': [{
-                    'checksum': hashlib.md5(str(uuid.uuid1()).encode('utf-8')).hexdigest(),
-                    'type': 'md5'
-                }]
-            }
-
-    @staticmethod
-    def generate_data_bundles(amount):
-        for bdl in TestCompliance.generate_data_objects(amount):
-            bdl.update({
-                'data_object_ids': [str(uuid.uuid1()), str(uuid.uuid1())],
-                'updated': '2018-08-29T19:58:52.648Z',
-                'version': str(uuid.uuid1()),
-            })
-            yield bdl


### PR DESCRIPTION
This is related to, but does not close, #159.
Compliance tests updated to:
* Address #154 
* Test providing multiple search criteria in ListDataObjects
* Provide utilities for generating random data objects and data bundles
* Beef up existing ListDataBundles, ListDataObjects tests

This is requisite to closing DataBiosphere/dos-azul-lambda#3. If this PR is merged, I will cut release 0.4.2