### PR TITLE
Add jsonschema==2.6.0 as a dependency (fixes #147)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 flake8==3.5.0
 nose==1.3.7
 Sphinx==1.7.4
-swagger-spec-validator==2.3.1

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         'connexion==1.4.2',
         'Flask-Cors==3.0.4',
         'bravado-core==4.13.4',
-        'bravado==9.2.2'
+        'bravado==9.2.2',
+        'jsonschema==2.6.0'
     ],
     license='Apache License 2.0',
     package_data={


### PR DESCRIPTION
Also remove swagger-spec-validator==2.3.1 as a development dependency.

See [here](https://github.com/ga4gh/data-object-service-schemas/issues/147#issuecomment-422174316) for reasoning